### PR TITLE
ci: add hotpath profiling && comment ci

### DIFF
--- a/.github/workflows/hotpath-comment.yml
+++ b/.github/workflows/hotpath-comment.yml
@@ -5,12 +5,6 @@ on:
     workflows: ["hotpath-profile"]
     types:
       - completed
-  workflow_dispatch:
-    inputs:
-      run_id:
-        description: "Workflow run id from hotpath-profile"
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -19,7 +13,7 @@ permissions:
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -32,7 +26,7 @@ jobs:
           path: /tmp/metrics/
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          run-id: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Install hotpath-utils CLI
         run: |

--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -43,6 +43,15 @@ jobs:
       - name: Checkout base
         run: git checkout ${{ github.event.pull_request.base.sha }}
 
+      - name: Inject benchmark harness into base checkout
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha }} -- \
+            tests/integration/hotpath_profile.rs \
+            tests/integration/main.rs
+          if ! grep -q "write_filtered_report_by_prefixes" src/hotpath_local.rs; then
+            git checkout ${{ github.event.pull_request.head.sha }} -- src/hotpath_local.rs
+          fi
+
       - name: Base benchmark
         env:
           BITCOIND_DOWNLOAD_ENDPOINT: https://bitcoincore.org/bin/bitcoin-core-28.1

--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -1,0 +1,71 @@
+name: hotpath-profile
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  profile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Create metrics directory
+        run: mkdir -p /tmp/metrics
+
+      - name: Head benchmark
+        env:
+          BITCOIND_DOWNLOAD_ENDPOINT: https://bitcoincore.org/bin/bitcoin-core-28.1
+          HOTPATH_OUTPUT_FORMAT: json
+          HOTPATH_OUTPUT_PATH: /tmp/metrics/head_full.json
+          COINSWAP_HOTPATH_MAKER_OUTPUT_PATH: /tmp/metrics/head_maker.json
+          COINSWAP_HOTPATH_TAKER_OUTPUT_PATH: /tmp/metrics/head_taker.json
+          HOTPATH_METRICS_SERVER_OFF: "1"
+          HOTPATH_FUNCTIONS_LIMIT: "0"
+          HOTPATH_FUNCTIONS_NAME_DEPTH: "0"
+          HOTPATH_THREADS_LIMIT: "0"
+        run: |
+          cargo test --release --test integration hotpath_profile_swap \
+            --features='integration-test hotpath hotpath-alloc' -- --nocapture
+
+      - name: Checkout base
+        run: git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Base benchmark
+        env:
+          BITCOIND_DOWNLOAD_ENDPOINT: https://bitcoincore.org/bin/bitcoin-core-28.1
+          HOTPATH_OUTPUT_FORMAT: json
+          HOTPATH_OUTPUT_PATH: /tmp/metrics/base_full.json
+          COINSWAP_HOTPATH_MAKER_OUTPUT_PATH: /tmp/metrics/base_maker.json
+          COINSWAP_HOTPATH_TAKER_OUTPUT_PATH: /tmp/metrics/base_taker.json
+          HOTPATH_METRICS_SERVER_OFF: "1"
+          HOTPATH_FUNCTIONS_LIMIT: "0"
+          HOTPATH_FUNCTIONS_NAME_DEPTH: "0"
+          HOTPATH_THREADS_LIMIT: "0"
+        run: |
+          cargo test --release --test integration hotpath_profile_swap \
+            --features='integration-test hotpath hotpath-alloc' -- --nocapture
+
+      - name: Save PR metadata
+        run: |
+          echo '${{ github.event.pull_request.number }}' > /tmp/metrics/pr_number.txt
+          echo '${{ github.base_ref }}' > /tmp/metrics/base_ref.txt
+          echo '${{ github.head_ref }}' > /tmp/metrics/head_ref.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: profile-metrics
+          path: /tmp/metrics/
+          retention-days: 1

--- a/src/hotpath_local.rs
+++ b/src/hotpath_local.rs
@@ -268,3 +268,39 @@ fn print_hotpath_tables_from_path(report_path: &Path) {
     print_section(&v, "functions_timing");
     print_section(&v, "functions_alloc");
 }
+
+/// Reads a Hotpath JSON report, filters function rows by name prefixes, and writes a new report.
+pub fn write_filtered_report_by_prefixes(
+    input_report_path: &Path,
+    output_report_path: &Path,
+    prefixes: &[&str],
+) -> std::io::Result<()> {
+    let mut report = read_json_with_retries(input_report_path)?;
+    for section_key in ["functions_timing", "functions_alloc"] {
+        let Some(rows) = report
+            .get_mut(section_key)
+            .and_then(|section| section.get_mut("data"))
+            .and_then(Value::as_array_mut)
+        else {
+            continue;
+        };
+
+        rows.retain(|row| {
+            row.get("name")
+                .and_then(Value::as_str)
+                .is_some_and(|name| prefixes.iter().any(|p| name.starts_with(p)))
+        });
+    }
+
+    if let Some(parent) = output_report_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(output_report_path)?;
+    serde_json::to_writer_pretty(std::io::BufWriter::new(file), &report)
+        .map_err(std::io::Error::other)
+}

--- a/tests/integration/hotpath_profile.rs
+++ b/tests/integration/hotpath_profile.rs
@@ -4,71 +4,13 @@ use crate::test_framework;
 
 use bitcoin::Amount;
 use coinswap::{
+    hotpath_local::write_filtered_report_by_prefixes,
     maker::{start_server, MakerBehavior},
     protocol::common_messages::ProtocolVersion,
     taker::{SwapParams, TakerBehavior},
     wallet::AddressType,
 };
-use serde_json::Value;
-use std::{env, path::PathBuf, sync::atomic::Ordering::Relaxed, thread, time::Duration};
-
-const IO_RETRIES: usize = 50;
-const IO_RETRY_SLEEP: Duration = Duration::from_millis(25);
-
-fn read_json_with_retries(path: &std::path::Path) -> std::io::Result<Value> {
-    let mut last_err = std::io::Error::new(
-        std::io::ErrorKind::NotFound,
-        format!("report not readable at {}", path.display()),
-    );
-    for _ in 0..IO_RETRIES {
-        match std::fs::read_to_string(path)
-            .and_then(|s| serde_json::from_str::<Value>(&s).map_err(std::io::Error::other))
-        {
-            Ok(v) => return Ok(v),
-            Err(e) => {
-                last_err = e;
-                thread::sleep(IO_RETRY_SLEEP);
-            }
-        }
-    }
-    Err(last_err)
-}
-
-fn write_filtered_report_by_prefixes(
-    input_report_path: &std::path::Path,
-    output_report_path: &std::path::Path,
-    prefixes: &[&str],
-) -> std::io::Result<()> {
-    let mut report = read_json_with_retries(input_report_path)?;
-
-    for section_key in ["functions_timing", "functions_alloc"] {
-        let Some(rows) = report
-            .get_mut(section_key)
-            .and_then(|section| section.get_mut("data"))
-            .and_then(Value::as_array_mut)
-        else {
-            continue;
-        };
-
-        rows.retain(|row| {
-            row.get("name")
-                .and_then(Value::as_str)
-                .is_some_and(|name| prefixes.iter().any(|p| name.starts_with(p)))
-        });
-    }
-
-    if let Some(parent) = output_report_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(output_report_path)?;
-    let writer = std::io::BufWriter::new(file);
-    serde_json::to_writer_pretty(writer, &report).map_err(std::io::Error::other)
-}
+use std::{env, path::PathBuf, sync::atomic::Ordering::Relaxed, thread};
 
 #[test]
 fn hotpath_profile_swap() {


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a clear and concise description of what this PR does and why it is needed. -->

## Related Issue(s)
Closes #<!-- replace with issue number if applicable -->
<!-- Add multiple lines if this PR closes multiple issues -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [ ] I ran `cargo +nightly fmt --all` and committed the result
- [ ] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [ ] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [ ] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [ ] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->
